### PR TITLE
- subtitle not constrained to show the amount of data

### DIFF
--- a/addon/components/frost-object-browser.js
+++ b/addon/components/frost-object-browser.js
@@ -51,13 +51,17 @@ export default Ember.Component.extend({
       return {}
     }
   },
-  
+
+  @readOnly
+  @computed('subtitle', 'showCountInSubTitle', 'computedValuesTotal')
   /**
    * Verifies the state of showCountInSubTitle variable before showing the subtitle
    * (in case someone doesn't need the counts)
+   * @param {String} subtitle - subtitle text
+   * @param {Boolean} showCountInSubTitle - whether or not to show count in subtitle
+   * @param {Number} count - number of items in list
+   * @returns {String} full subtitle to show in UI
    */
-  @readOnly
-  @computed('subtitle', 'showCountInSubTitle', 'computedValuesTotal')
   computedSubtitle (subtitle, showCountInSubTitle, count) {
     return showCountInSubTitle ? `${count} – ${subtitle}` : subtitle
   },

--- a/addon/components/frost-object-browser.js
+++ b/addon/components/frost-object-browser.js
@@ -30,6 +30,7 @@ export default Ember.Component.extend({
   subtitle: '',
   title: '',
   valuesTotal: null,
+  showCountInSubTitle: true,
 
   // ================================================================
   // Computed Properties
@@ -49,6 +50,16 @@ export default Ember.Component.extend({
     } else {
       return {}
     }
+  },
+  
+  /**
+   * Verifies the state of showCountInSubTitle variable before showing the subtitle
+   * (in case someone doesn't need the counts)
+   */
+  @readOnly
+  @computed('subtitle', 'showCountInSubTitle', 'computedValuesTotal')
+  computedSubtitle (subtitle, showCountInSubTitle, count) {
+    return showCountInSubTitle ? `${count} – ${subtitle}` : subtitle
   },
 
   /**

--- a/addon/templates/components/frost-object-browser.hbs
+++ b/addon/templates/components/frost-object-browser.hbs
@@ -3,9 +3,9 @@
     <div class="primary-title">
       {{title}}
     </div>
-    {{# if subtitle}}
-     <div class='sub-title'>{{computedValuesTotal}} - {{subtitle}}</div>
-    {{/if}}
+    <div class="sub-title">
+      {{computedSubtitle}}
+    </div>
   </div>
   <div class="top-buttons" background-color='red'>
     {{frost-button

--- a/tests/unit/components/frost-object-browser-test.js
+++ b/tests/unit/components/frost-object-browser-test.js
@@ -258,4 +258,25 @@ describeComponent('frost-object-browser', 'Unit | frost-object-browser', {
       expect(component.get('detailLevel')).to.equal(detailLevel)
     })
   })
+
+  it('computedSubtitle is computed properly when showCountInSubTitle is false', function () {
+    Ember.run(() => {
+      component.setProperties({
+        showCountInSubTitle: false,
+        subtitle: 'hello'
+      })
+    })
+    expect(component.get('computedSubtitle')).to.equal('hello')
+  })
+
+  it('computedSubtitle is computed properly when showCountInSubTitle is true', function () {
+    Ember.run(() => {
+      component.setProperties({
+        showCountInSubTitle: true,
+        subtitle: 'hello',
+        valuesTotal: 2
+      })
+    })
+    expect(component.get('computedSubtitle')).to.equal('2 – hello')
+  })
 })


### PR DESCRIPTION
Hi, I think the subtitle should be more flexible this way. Here is a use case where the subtitle as it is is not working for us...
UX want me to display in the sub title...
**There are 5 tenants, 30 assets group and 2 users**
but because the way it is set now I'm getting...
**5 - There are 5 tenants, 30 assets group and 2 users**

Since it's easy to get this value from the model I don't see why we have to restrain people to format the subtitle like this...** {num} - "the string"**
#minor#