### PR TITLE
Use ember-prop-types

### DIFF
--- a/addon/components/frost-object-browser.js
+++ b/addon/components/frost-object-browser.js
@@ -2,6 +2,7 @@ import Ember from 'ember'
 import _ from 'lodash'
 import computed, {readOnly} from 'ember-computed-decorators'
 import layout from '../templates/components/frost-object-browser'
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 
 /**
  * @type SelectedRecord
@@ -9,7 +10,7 @@ import layout from '../templates/components/frost-object-browser'
  * @property {Object} record - the record itself
  */
 
-export default Ember.Component.extend({
+export default Ember.Component.extend(PropTypeMixin, {
   // ================================================================
   // Dependencies
   // ================================================================
@@ -19,17 +20,34 @@ export default Ember.Component.extend({
   // ================================================================
 
   classNames: ['frost-object-browser'],
-  contentHeight: 505,
-  detailLevel: 'low',
-  itemsPerPage: 20,
   layout,
-  pageNumber: null,
   _pageNumber: 0,
-  selectedItems: Ember.A([]),
-  subtitle: '',
-  title: '',
-  valuesTotal: null,
-  showCountInSubTitle: true,
+
+  propTypes: {
+    contentHeight: PropTypes.number,
+    detailLevel: PropTypes.string,
+    itemsPerPage: PropTypes.number,
+    pageNumber: PropTypes.number,
+    selectedItems: PropTypes.array,
+    subtitle: PropTypes.string,
+    showCountInSubTitle: PropTypes.bool,
+    title: PropTypes.string,
+    valuesTotal: PropTypes.number
+  },
+
+  getDefaultProps () {
+    return {
+      contentHeight: 505,
+      detailLevel: 'low',
+      itemsPerPage: 20,
+      pageNumber: null,
+      selectedItems: Ember.A([]),
+      subtitle: '',
+      title: '',
+      valuesTotal: null,
+      showCountInSubTitle: true
+    }
+  },
 
   // ================================================================
   // Computed Properties


### PR DESCRIPTION
`selectedItems` was initialized in the definition of `frost-object-browser` causing issues with multiple pages sharing selection state.

#PATCH#