### PR TITLE
Move filters to a block-slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,12 @@ ember install ember-frost-object-browser
   title="Resources"
   values=model.visibleResources
   viewSchema=viewSchema
-}}
+as |slot|}}
   {{block-slot slot 'actions'}}
     <!-- actions go here -->
+  {{/block-slot}}
+  {{#block-slot slot 'filters' as |filters onFilter|}}
+    {{frost-object-browser-filter filters=filters onFilter=onFilter}}
   {{/block-slot}}
 {{/frost-object-browser}}
 ```

--- a/addon/templates/components/frost-object-browser.hbs
+++ b/addon/templates/components/frost-object-browser.hbs
@@ -1,3 +1,4 @@
+{{yield}}
 <div class="frost-info-bar">
   <div class="title">
     <div class="primary-title">
@@ -19,9 +20,9 @@
   </div>
 </div>
 <div class="body">
-    {{#if filters}}
-    {{frost-object-browser-filter filters=filters onFilter=onFilter}}
-    {{/if}}
+  {{#yield-slot 'filters'}}
+    {{yield (block-params filters onFilter)}}
+  {{/yield-slot}}
   <div class="content">
     <div class="tools">
       <div class="sort"/>
@@ -79,7 +80,6 @@
         }}
       {{/frost-object-browser-list-item}}
     {{/frost-list}}
-    {{yield}}
     <div class="actions">
       {{#yield-slot 'actions'}}
         {{yield 'actions'}}

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -26,5 +26,4 @@ as |slot|}}
   {{#block-slot slot 'filters' as |filters onFilter|}}
     {{frost-object-browser-filter filters=filters onFilter=onFilter}}
   {{/block-slot}}
-
 {{/frost-object-browser}}

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -10,7 +10,7 @@
   values=model.resources
   viewSchema=viewSchema
   filters=filters
-}}
+as |slot|}}
   {{#block-slot slot 'actions'}}
     {{#each actionBarItems as |actionBarItem|}}
       {{#frost-button
@@ -23,4 +23,8 @@
       {{/frost-button}}
     {{/each}}
   {{/block-slot}}
+  {{#block-slot slot 'filters' as |filters onFilter|}}
+    {{frost-object-browser-filter filters=filters onFilter=onFilter}}
+  {{/block-slot}}
+
 {{/frost-object-browser}}


### PR DESCRIPTION
#MAJOR#

Moved the filters functionality to a block slot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-frost/ember-frost-object-browser/26)
<!-- Reviewable:end -->
