### PR TITLE
Moved the object display "results canvas" section to a block slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,47 @@
+# 10.0
+
+## Breaking Changes
+* **Removed** support for the frost-list being built into the object-browser (what is showing the object data in list view)
+* **Added** support for the object data as a named block slot
+  This was done to increase the flexibilty of what can be set to handle the object data.
+  The new usage allows for these actions to be passed into the component's block
+  section:
+
+  ```handlebars
+  {#frost-object-browser
+    facets=model.facets
+    filters=filters
+    model=model.model
+    onCreate=(action 'onCreate')
+    onDetailChange=(action 'onDetailChange')
+    onFacetChange=(action 'onOptionSelected')
+    onFilter=onFilter
+    onRowSelect=(action 'onRowSelect')
+    title='Resources'
+    values=model.visibleResources
+    viewSchema=viewSchema
+  as |slot|}}
+    {{#block-slot slot 'objects' as |object onSelect|}}
+      {{#frost-list onSelect=(action onSelect) selections=object.selectedItems records=object.computedValues as |record|}}
+        {{#frost-object-browser-list-item model=record as |value|}}
+          {{frost-bunsen-detail
+            model=object.model
+            renderers=object.renderers
+            value=value
+            view=object.computedViewLevel
+          }}
+        {{/frost-object-browser-list-item}}
+      {{/frost-list}}
+    {{/block-slot}}
+  {{/frost-object-browser}}
+  ```
+
+
 # 9.0
 
 ## Breaking Changes
-* **Removed** support for `app-actions` (create at the app level)
-* **Added** for `app-actions` as a named block slot
+* **Removed** support for application level actions (create at the app level)
+* **Added** support for application level actions as a named block slot
   This was done to increase the flexibilty of what can be set as the `app-actions`.
   The new usage allows for these actions to be passed into the component's block
   section:
@@ -37,11 +76,11 @@
 # 8.0
 
 ## Breaking Changes
-* **Removed** support for `button-bar` (level of detail controls)
-* **Added** for `button-bar` level of detail controls as a named block slot
-  This was done to increase the flexibilty of what can be used as the `button-bar`
-  level of detail controls. The new usage allows for these controls to be passed into
-  the component's block section:
+* **Removed** support for the button bar (level of detail controls)
+* **Added** support for the button bar level of detail controls as a named block slot
+  This was done to increase the flexibilty of what can be used as the level of detail
+  controls. The new usage allows for these controls to be passed into the component's
+  block section:
 
   ```handlebars
   {#frost-object-browser
@@ -94,9 +133,9 @@
 # 7.0
 
 ## Breaking Changes
-* **Removed** support for `info-bar` content (title and subtitle information)
-* **Added** for `info-bar` content as a named block slot
-  This was done to increase the flexibilty of what can be used as the `info-bar`
+* **Removed** support for the info bar content (title and subtitle information)
+* **Added** support for the info bar content as a named block slot
+  This was done to increase the flexibilty of what can be used as the info bar
   content. The new usage allows for these content to be passed into
   the component's block section:
 
@@ -128,9 +167,9 @@
 # 6.0
 
 ## Breaking Changes
-* **Removed** support for `filter-pane` content (filters)
-* **Added** for `filter-pane` content as a named block slot
-  This was done to increase the flexibilty of what can be used as the `filter-pane`
+* **Removed** support for the filter pane content (filters)
+* **Added** support for the filter pane content as a named block slot
+  This was done to increase the flexibilty of what can be used as the filter pane
   content. The new usage allows for these content to be passed into
   the component's block section:
 
@@ -169,9 +208,9 @@
 # 5.0
 
 ## Breaking Changes
-* **Removed** support for `row-actions` content (actions on records: edit, delete, details)
-* **Added** for `row-actions` content as a named block slot
-  This was done to increase the flexibilty of what can be used as the `row-actions`
+* **Removed** support for the row actions content (actions on records: edit, delete, details)
+* **Added** support for the row actions content as a named block slot
+  This was done to increase the flexibilty of what can be used as the row actions
   content. The new usage allows for these content to be passed into
   the component's block section:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * **Removed** support for the frost-list being built into the object-browser (what is showing the object data in list view)
 * **Added** support for the object data as a named block slot
   This was done to increase the flexibilty of what can be set to handle the object data.
-  The new usage allows for these actions to be passed into the component's block
+  The new usage allows for this object data to be passed into the component's block
   section:
 
   ```handlebars

--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ as |slot|}}
       vertical=true
     }}
   {{/block-slot}}
-  {{block-slot slot 'row-actions'}}
-    <!-- actions go here -->
-  {{/block-slot}}
   {{#block-slot slot 'filters' as |filters onFilter|}}
     {{frost-object-browser-filter filters=filters onFilter=onFilter}}
   {{/block-slot}}
@@ -66,6 +63,21 @@ as |slot|}}
     <div class="sub-title">
       {{infoBar.summary}}
     </div>
+  {{/block-slot}}
+  {{#block-slot slot 'objects' as |object onSelect|}}
+    {{#frost-list onSelect=(action onSelect) selections=object.selectedItems records=object.computedValues as |record|}}
+      {{#frost-object-browser-list-item model=record as |value|}}
+        {{frost-bunsen-detail
+          model=object.model
+          renderers=object.renderers
+          value=value
+          view=object.computedViewLevel
+        }}
+      {{/frost-object-browser-list-item}}
+    {{/frost-list}}
+  {{/block-slot}}
+  {{block-slot slot 'object-actions'}}
+    <!-- actions go here -->
   {{/block-slot}}
   {{#block-slot slot 'view-controls' as |viewControl viewLevel onDetailChange|}}
     <div class="button-bar {{ viewControl.detailLevel }}">

--- a/addon/templates/components/frost-object-browser.hbs
+++ b/addon/templates/components/frost-object-browser.hbs
@@ -36,18 +36,14 @@
         {{/yield-slot}}
       </div>
     </div>
-    {{#frost-list onSelect=(action 'onSelect') selections=selectedItems records=computedValues as |record|}}
-      {{#frost-object-browser-list-item model=record as |value|}}
-        {{frost-bunsen-detail
-          model=model
-          renderers=renderers
-          value=value
-          view=computedViewLevel
-        }}
-      {{/frost-object-browser-list-item}}
-    {{/frost-list}}
+    {{#yield-slot 'objects'}}
+      {{yield (block-params this (action 'onSelect'))}}
+    {{/yield-slot}}
+
+
+
     <div class="actions">
-      {{#yield-slot 'row-actions'}}
+      {{#yield-slot 'object-actions'}}
         {{yield 'actions'}}
       {{/yield-slot}}
     </div>

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -21,18 +21,6 @@ as |slot|}}
       vertical=true
     }}
   {{/block-slot}}
-  {{#block-slot slot 'row-actions'}}
-    {{#each actionBarItems as |actionBarItem|}}
-      {{#frost-button
-        disabled=(not actionBarItem.enabled)
-        onClick=(action 'onActionClick' actionBarItem.id)
-        priority='secondary'
-        size='large'
-      }}
-        <div class="text">{{actionBarItem.label}}</div>
-      {{/frost-button}}
-    {{/each}}
-  {{/block-slot}}
   {{#block-slot slot 'filters' as |filters onFilter|}}
     {{frost-object-browser-filter filters=filters onFilter=onFilter}}
   {{/block-slot}}
@@ -43,6 +31,30 @@ as |slot|}}
     <div class="sub-title">
       {{infoBar.summary}}
     </div>
+  {{/block-slot}}
+  {{#block-slot slot 'objects' as |object onSelect|}}
+    {{#frost-list onSelect=(action onSelect) selections=object.selectedItems records=object.computedValues as |record|}}
+      {{#frost-object-browser-list-item model=record as |value|}}
+        {{frost-bunsen-detail
+          model=object.model
+          renderers=object.renderers
+          value=value
+          view=object.computedViewLevel
+        }}
+      {{/frost-object-browser-list-item}}
+    {{/frost-list}}
+  {{/block-slot}}
+  {{#block-slot slot 'object-actions'}}
+    {{#each actionBarItems as |actionBarItem|}}
+      {{#frost-button
+        disabled=(not actionBarItem.enabled)
+        onClick=(action 'onActionClick' actionBarItem.id)
+        priority='secondary'
+        size='large'
+      }}
+        <div class="text">{{actionBarItem.label}}</div>
+      {{/frost-button}}
+    {{/each}}
   {{/block-slot}}
   {{#block-slot slot 'view-controls' as |viewControl viewLevel onDetailChange|}}
     <div class="button-bar {{ viewControl.detailLevel }}">

--- a/tests/integration/components/frost-object-browser-test.js
+++ b/tests/integration/components/frost-object-browser-test.js
@@ -120,16 +120,6 @@ describeComponent(
       expect(this.$()).to.have.length(1)
     })
 
-    it('renders 6 items per page', function () {
-      this.timeout(8000)
-      this.render(hbs`{{frost-object-browser
-        itemsPerPage=6
-        values=model.resources
-        model=model.model
-      }}`)
-      expect(this.$().find('.frost-list-item')).to.have.length(6)
-    })
-
     it('it changes page when we click to next change button', function () {
       this.timeout(8000)
       this.render(hbs`{{frost-object-browser


### PR DESCRIPTION
#MAJOR#

Moved the object display section to a block slot
Updated the CHANGELING
Changed the name of row-actions slot to object-actions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-frost/ember-frost-object-browser/38)
<!-- Reviewable:end -->
