### PR TITLE
fixed the actions slot component integration test

### DIFF
--- a/tests/integration/components/frost-object-browser-test.js
+++ b/tests/integration/components/frost-object-browser-test.js
@@ -80,7 +80,7 @@ describeComponent(
       expect(
         this.$().text().trim().replace(/ +/g, ' '),
         'Text shows in the "actions" yielded slot'
-      ).to.eql('items selected\n Some yielded text')
+      ).to.eql('0 items selected\n Some yielded text')
     })
 
     it('it yields a button contextual component in the "actions" slot', function () {


### PR DESCRIPTION
#PATCH#

Closes: https://github.com/ciena-frost/ember-frost-object-browser/issues/75

# Changelog
* **Fixed** the FrostObjectBrowserComponent integration test "it yields the 'actions' slot"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-frost/ember-frost-object-browser/76)
<!-- Reviewable:end -->
