### PR TITLE
updated blueprint for info-bar and exanded usage of sinon-chai to dev…

### DIFF
--- a/blueprints/ember-frost-object-browser/index.js
+++ b/blueprints/ember-frost-object-browser/index.js
@@ -14,7 +14,7 @@ module.exports = {
         {name: 'ember-block-slots', target: '>=0.12.1 <2.0.0'},
         {name: 'ember-frost-core', target: '>=0.2.1 <2.0.0'},
         {name: 'ember-frost-bunsen', target: '^6.0.0'},
-        {name: 'ember-frost-info-bar', target: '^2.0.0'},
+        {name: 'ember-frost-info-bar', target: '^3.0.0'},
         {name: 'ember-frost-list', target: '>=0.5.0 <2.0.0'},
         {name: 'ember-prop-types', target: '^2.0.0'},
         {name: 'liquid-fire', target: '>=0.23.0 <2.0.0'}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -15,7 +15,7 @@ module.exports = function (defaults) {
     }
   })
 
-  if (app.env === 'test') {
+  if (app.env === 'test' || app.env === 'development') {
     app.import('bower_components/sinon-chai/lib/sinon-chai.js', {type: 'test'})
   }
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "ember-frost-info-bar": "^3.0.0",
     "ember-frost-list": "0.7.4",
     "ember-frost-sort": "2.1.1",
-    "ember-hook": "1.2.1",
     "ember-load-initializers": "^0.5.1",
     "ember-lodash-shim": "0.1.3",
     "ember-one-way-controls": "1.0.0",

--- a/tests/unit/components/frost-object-browser-inline-test.js
+++ b/tests/unit/components/frost-object-browser-inline-test.js
@@ -222,16 +222,16 @@ describeComponent('frost-object-browser-inline', 'Unit | frost-object-browser-in
     component.set('sendAction', sendAction)
 
     component.actions.onPageChanged.call(component, 'forward')
-    expect(sendAction.calledWith('onPageChanged', 3)).to.be.ok
+    expect(sendAction.firstCall).to.have.been.calledWith('onPageChanged', 3)
 
     component.actions.onPageChanged.call(component, 'back')
-    expect(sendAction.calledWith('onPageChanged', 1)).to.be.ok
+    expect(sendAction).to.have.been.calledWith('onPageChanged', 1)
 
     component.actions.onPageChanged.call(component, 'end')
-    expect(sendAction.calledWith('onPageChanged', 3)).to.be.ok
+    expect(sendAction).to.have.been.calledWith('onPageChanged', 3)
 
     component.actions.onPageChanged.call(component, 'begin')
-    expect(sendAction.calledWith('onPageChanged', 0)).to.be.ok
+    expect(sendAction).to.have.been.calledWith('onPageChanged', 0)
   })
 
   it('sets detailLevel when LOD buttons are clicked', function () {


### PR DESCRIPTION
#PATCH#

Closes: https://github.com/ciena-frost/ember-frost-object-browser/issues/78

# CHANGELOG

* **Updated** `ember-frost-info-bar` dependency in blueprint to latest version.
* **Updated** usage of sinon-chai to include the development environment.
* **Removed** `ember-hook` devDependency since it is not being used.
