### PR TITLE
Fix Ember.Date.parse deprecation notice introduced in ember-data v2.7.0

### DIFF
--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -12,6 +12,9 @@ module.exports = function (environment) {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
+      },
+      EXTEND_PROTOTYPES: {
+        Date: false
       }
     },
 


### PR DESCRIPTION
#FIX#

Closes: https://github.com/ciena-frost/ember-frost-object-browser/issues/80

# CHANGELOG

* **Added** configuration option to turn off prototype extensions for Date.
