### PR TITLE
Add _super() call in init()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ deploy:
   api_key:
     secure: XiEdGMKhQEedVZJPPvcnUEX3RjXW8DQiJxvy5e3BRHNwMB/ARqVkagZF6imOYwGk59V/7nLw4awDPhU+9TjsyOz+Xo90VmtM3vK80D5tm9jkGY7GWxDrRk3yPBcqcGZbygiu8vlbSes6wXl6jGdnClQAJnMZI/WBYyyTaGJDEgKUo4hhME6S+iDVM9Im6TFM7DQdVPNP7A8nu/uhzE71Xb5SyvI+4XYY4V6E00P7auOTTnzYNjCSt6B51ucQo3X/b3stbWAEpwPpdAw0trR62djykNJJtUd3YP6hNwyfgMhFSDOu19J9DPWSPIBGH2vQZ4v4OBd5o8jpBM3XcmpceN7bPtdX08i5lDZsdzv7QQvTUbImatMKOrWbeNeMqhVC/vdHqyabGKC6UaLReVkFcfBQWmGGmzlhQq30iB1mNIMME2ZSUP0lDsMIpzpz6qbVNjhllpeX3PEXu3oth8DkJ6SLNSQU4J5iI//z+/0p0GLF+yGSps/Ofa1SsRvsMmKoyyX10G42FeVUB/SZdKMijNbuN/z2xIHIOmFV3VN/t7+wIvR1eAjQe8RKEwH0p5IyNMwjRDPpjZYcY4MpkAOT4ea5VbnR6qtU2JaiD4T93hp1/Ic3/GY4kerv6SPXcrm/cedSiCI6lB2lVSWqGa078B5vk8NMsB5bf0/1mD6Q9x0=
   on:
-    branch: master
+    branch: 13.0.x
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
     tags: false

--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ module.exports = {
   },
 
   init: function (app) {
+    if (this._super.init) {
+      this._super.init.apply(this, arguments)
+    }
+
     this.options = this.options || {}
     this.options.babel = this.options.babel || {}
     this.options.babel.optional = this.options.babel.optional || []

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
-    "ember-block-slots": ">=0.12.1 <2.0.0",
+    "ember-block-slots": ">=0.12.1 <1.0.0",
     "ember-browserify": "^1.1.9",
     "ember-cli": "^2.4.3",
     "ember-cli-app-version": "^1.0.0",


### PR DESCRIPTION
This #patch# change allows for `ember-frost-object-browser` to work with `ember-cli@2.8`

# CHANGELOG

 * **Added** `_super()` call in the `init()` method in `index.js` for compatibility with `ember-cli@2.8`