### PR TITLE
Only show facet DOM when filters present

### DIFF
--- a/addon/templates/components/frost-object-browser.hbs
+++ b/addon/templates/components/frost-object-browser.hbs
@@ -1,11 +1,13 @@
-<div class='{{css}}-facets'>
-  <div class='{{css}}-facets-header'>
-    Refine by
+{{#if filters}}
+  <div class='{{css}}-facets'>
+    <div class='{{css}}-facets-header'>
+      Refine by
+    </div>
+    {{#frost-scroll class=(concat css '-facets-body')}}
+      {{component filters}}
+    {{/frost-scroll}}
   </div>
-  {{#frost-scroll class=(concat css '-facets-body')}}
-    {{component filters}}
-  {{/frost-scroll}}
-</div>
+{{/if}}
 <div class='{{css}}-content'>
   {{component content}}
   {{component controls}}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `frost-object-browser` component to only show facets DOM when the `filters` property is present.
