### PR TITLE
fix(usage): Use flex based layout for action-bar

### DIFF
--- a/addon/components/frost-object-browser.js
+++ b/addon/components/frost-object-browser.js
@@ -1,10 +1,3 @@
-/**
- * TODO
- */
-
-import Ember from 'ember'
-const {isEmpty} = Ember
-import computed, {readOnly} from 'ember-computed-decorators'
 import {Component} from 'ember-frost-core'
 import {PropTypes} from 'ember-prop-types'
 
@@ -12,7 +5,7 @@ import layout from '../templates/components/frost-object-browser'
 
 export default Component.extend({
   // == Dependencies ==========================================================
-
+  layout,
   // == Properties ============================================================
   propTypes: {
     // Options
@@ -24,13 +17,8 @@ export default Component.extend({
   },
 
   getDefaultProps () {
-    return {
-      // Keywords
-      layout
-
-      // Options
-    }
-  },
+    return {}
+  }
 
   // == Computed Properties ===================================================
 

--- a/addon/components/frost-object-browser.js
+++ b/addon/components/frost-object-browser.js
@@ -14,15 +14,12 @@ export default Component.extend({
   // == Dependencies ==========================================================
 
   // == Properties ============================================================
-  classNameBindings: ['_isActionsVisible:actions-visible'],
   propTypes: {
     // Options
     content: PropTypes.EmberObject.isRequired,
     controls: PropTypes.EmberObject.isRequired,
     hook: PropTypes.string.isRequired,
-    filters: PropTypes.EmberObject.isRequired,
-    selectedItems: PropTypes.EmberObject.isRequired
-
+    filters: PropTypes.EmberObject.isRequired
     // State
   },
 
@@ -36,12 +33,6 @@ export default Component.extend({
   },
 
   // == Computed Properties ===================================================
-
-  @readOnly
-  @computed('controls.[]', 'items.@each.isSelected')
-  _isActionsVisible (controls, items) {
-    return !isEmpty(controls) && !isEmpty(items) && items.isAny('isSelected', true)
-  }
 
   // == Functions =============================================================
 

--- a/addon/styles/_frost-action-bar.scss
+++ b/addon/styles/_frost-action-bar.scss
@@ -3,8 +3,7 @@ $frost-action-bar-background-color: rgba($frost-color-white, 0.85);
 
 .frost-action-bar {
   display: flex;
-  position: absolute;
-  bottom: 0;
+  position: relative;
   left: 1px;
   flex-direction: row;
   justify-content: space-between;

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -116,9 +116,9 @@ $frost-object-browser-actions-box-shadow: 0 8px 8px -8px #696868, 0 -8px 8px -8p
 
   &-content {
     display: flex;
-    flex-direction: column;
     position: relative;
     flex: 1;
+    flex-direction: column;
     min-width: 0;
     height: 100%;
   }

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -24,12 +24,6 @@ $frost-object-browser-actions-box-shadow: 0 8px 8px -8px #696868, 0 -8px 8px -8p
     height: 100%;
   }
 
-  &.actions-visible {
-    .frost-list-content-container {
-      margin-bottom: $frost-action-bar-height;
-    }
-  }
-
   .frost-list-content-container {
     &.paged {
       &:before {
@@ -121,6 +115,8 @@ $frost-object-browser-actions-box-shadow: 0 8px 8px -8px #696868, 0 -8px 8px -8p
   }
 
   &-content {
+    display: flex;
+    flex-direction: column;
     position: relative;
     flex: 1;
     min-width: 0;

--- a/tests/dummy/app/pods/client/template.hbs
+++ b/tests/dummy/app/pods/client/template.hbs
@@ -1,5 +1,4 @@
 {{frost-object-browser
-  items=items
   filters=(component 'frost-bunsen-form'
     autofocus=false
     bunsenModel=filterModel

--- a/tests/dummy/app/pods/server/template.hbs
+++ b/tests/dummy/app/pods/server/template.hbs
@@ -1,7 +1,5 @@
 <div class='frost-object-browser-route'>
   {{frost-object-browser
-    items=items
-    selectedItems=selectedItems
     filters=(component 'frost-bunsen-form'
       autofocus=false
       bunsenModel=filterModel


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

## Demo
https://srowhani.github.io/ember-frost-object-browser/

# CHANGELOG
- Removed classNameBindings, and propTypes for unused selectedItems
- Change action-bar from absolute positioning to flex layout