### PR TITLE
Move ember-prop-types config to dummy app

### DIFF
--- a/addon/components/frost-action-bar.js
+++ b/addon/components/frost-action-bar.js
@@ -23,6 +23,7 @@ export default Component.extend({
   propTypes: {
     // options
     controls: PropTypes.arrayOf(PropTypes.EmberComponent).isRequired,
+    // FIXME: for next major release, make this `i18n.messages.selectedItems()` (@job13er 2017-06-06)
     i18n: PropTypes.shape({
       formatSelectedItemsLabel: PropTypes.func.isRequired
     }),

--- a/addon/components/frost-object-browser.js
+++ b/addon/components/frost-object-browser.js
@@ -12,6 +12,7 @@ export default Component.extend({
     content: PropTypes.EmberComponent.isRequired,
     controls: PropTypes.EmberComponent.isRequired,
     filters: PropTypes.EmberComponent.isRequired,
+    // FIXME: For the next major release, make this `i18n.labels.refineBy` (@job13er 2017-06-06)
     i18n: PropTypes.shape({
       refineByLabel: PropTypes.string.isRequired
     })

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,9 +1,5 @@
 'use strict'
 
 module.exports = function (/* environment, appConfig */) {
-  return {
-    'ember-prop-types': {
-      throwErrors: true
-    }
-  }
+  return {}
 }

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -8,6 +8,9 @@ module.exports = function (environment) {
     environment: environment,
     rootURL: '/',
     locationType: 'hash',
+    'ember-prop-types': {
+      throwErrors: true
+    },
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** `config/environment.js` to no longer affect consumer's environment (resolves [#24](https://github.com/ciena-frost/ember-frost-object-browser/issues/124))