### PR TITLE
Remove old .eslintrc config file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": ["frost-standard"],
-  "rules": {
-    "valid-jsdoc": [0]
-  }
-}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [X] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Removed** old `.eslintrc` file that is not needed since we are now using the `.eslintrc.js` file