### PR TITLE
Fix cannot call "writewatching" after the object is destroyed

### DIFF
--- a/addon/helpers/multi-select.js
+++ b/addon/helpers/multi-select.js
@@ -15,7 +15,7 @@ export default Helper.extend({
   },
   setupRecompute (selectedItems, property) {
     if (this.teardown) this.teardown()
-    var path = '@each.id'
+    var path = '[]'
     selectedItems.addObserver(path, this, this.recompute)
     this.teardown = () => {
       selectedItems.removeObserver(path, this, this.recompute)


### PR DESCRIPTION
Needed to change `@each.id` to `[]` since the computed property was crashing because it would try to watch the id of a destroyed object.  (Happens in Ember 2.12, wasn't occurring when our addon targeted 2.11.x)

### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [x] #major# - incompatible API change

# CHANGELOG
* Fixed error `cannot call "writewatching" after the object is destroyed` 
  * Resulting from attempting to watch the dependent key `id` on a destroyed object

