### PR TITLE
List item types and controls

### DIFF
--- a/addon/components/frost-action-bar.js
+++ b/addon/components/frost-action-bar.js
@@ -3,12 +3,13 @@
  */
 
 import Ember from 'ember'
-const {isEmpty} = Ember
+const {get, getWithDefault, isEmpty, isPresent, typeOf} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {Component} from 'ember-frost-core'
 import {PropTypes} from 'ember-prop-types'
 
 import layout from '../templates/components/frost-action-bar'
+import {applicableControls} from '../utils/controls'
 
 export default Component.extend({
 
@@ -22,7 +23,10 @@ export default Component.extend({
 
   propTypes: {
     // options
-    controls: PropTypes.arrayOf(PropTypes.EmberComponent).isRequired,
+    controls: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.EmberComponent).isRequired,
+      PropTypes.object.isRequired
+    ]),
     // FIXME: for next major release, make this `i18n.messages.selectedItems()` (@job13er 2017-06-06)
     i18n: PropTypes.shape({
       formatSelectedItemsLabel: PropTypes.func.isRequired
@@ -31,6 +35,11 @@ export default Component.extend({
       PropTypes.EmberObject,
       PropTypes.object
     ])).isRequired,
+    itemTypeKey: PropTypes.string,
+    componentKeyNamesForTypes: PropTypes.oneOfType([
+      PropTypes.EmberObject,
+      PropTypes.object
+    ]),
 
     // callbacks
     getSelectedItemsLabel: PropTypes.func
@@ -66,9 +75,43 @@ export default Component.extend({
   @computed('selectedItems.[]')
   selectedItemsLabel (selectedItems) {
     return this.i18n.formatSelectedItemsLabel(selectedItems.length)
-  }
+  },
+
+  @readOnly
+  @computed('controls')
+  isControlsObject (controls) {
+    return typeOf(controls) === 'object'
+  },
+
+  @readOnly
+  @computed('isVisible', 'isControlsObject', 'controls', 'selectedItems.[]')
+  _controls (isVisible, isControlsObject, controls, selectedItems) {
+    if (isVisible && isControlsObject && isPresent(controls) && isPresent(selectedItems)) {
+      return applicableControls(this.selectedTypesWithControls(selectedItems)).map((controlName) => {
+        return controls[controlName]
+      })
+    }
+
+    return controls
+  },
 
   // == Functions =============================================================
+
+  selectedTypesWithControls (selectedItems) {
+    const componentKeyNamesForTypes = this.get('componentKeyNamesForTypes')
+    const itemTypeKey = this.get('itemTypeKey')
+    const componentKeyNames = this.get('componentKeyNames')
+
+    if (isPresent(componentKeyNamesForTypes) && isPresent(itemTypeKey)) {
+      return selectedItems.reduce((typesWithControls, item) => {
+        const itemType = get(item, itemTypeKey)
+        const itemTypeContent = getWithDefault(componentKeyNamesForTypes, itemType, {})
+        const itemTypeContentControls = getWithDefault(itemTypeContent, get(componentKeyNames, 'controls'), [])
+        typesWithControls[itemType] = itemTypeContentControls
+        return typesWithControls
+      }, {})
+    }
+  }
 
   // == DOM Events ============================================================
 

--- a/addon/components/frost-action-bar.js
+++ b/addon/components/frost-action-bar.js
@@ -84,9 +84,9 @@ export default Component.extend({
   },
 
   @readOnly
-  @computed('isVisible', 'isControlsObject', 'controls', 'selectedItems.[]')
-  _controls (isVisible, isControlsObject, controls, selectedItems) {
-    if (isVisible && isControlsObject && isPresent(selectedItems)) {
+  @computed('isControlsObject', 'controls', 'selectedItems.[]')
+  _controls (isControlsObject, controls, selectedItems) {
+    if (isControlsObject) {
       return applicableControls(this.selectedTypesWithControls(selectedItems)).map((controlName) => {
         return controls[controlName]
       })

--- a/addon/components/frost-action-bar.js
+++ b/addon/components/frost-action-bar.js
@@ -105,9 +105,11 @@ export default Component.extend({
     if (isPresent(componentKeyNamesForTypes) && isPresent(itemTypeKey)) {
       return selectedItems.reduce((typesWithControls, item) => {
         const itemType = get(item, itemTypeKey)
-        const itemTypeContent = getWithDefault(componentKeyNamesForTypes, itemType, {})
-        const itemTypeContentControls = getWithDefault(itemTypeContent, get(componentKeyNames, 'controls'), [])
-        typesWithControls[itemType] = itemTypeContentControls
+        if (itemType) {
+          const itemTypeContent = getWithDefault(componentKeyNamesForTypes, itemType, {})
+          const itemTypeContentControls = getWithDefault(itemTypeContent, get(componentKeyNames, 'controls'), [])
+          typesWithControls[itemType] = itemTypeContentControls
+        }
         return typesWithControls
       }, {})
     }

--- a/addon/components/frost-action-bar.js
+++ b/addon/components/frost-action-bar.js
@@ -86,7 +86,7 @@ export default Component.extend({
   @readOnly
   @computed('isVisible', 'isControlsObject', 'controls', 'selectedItems.[]')
   _controls (isVisible, isControlsObject, controls, selectedItems) {
-    if (isVisible && isControlsObject && isPresent(controls) && isPresent(selectedItems)) {
+    if (isVisible && isControlsObject && isPresent(selectedItems)) {
       return applicableControls(this.selectedTypesWithControls(selectedItems)).map((controlName) => {
         return controls[controlName]
       })

--- a/addon/templates/components/frost-action-bar.hbs
+++ b/addon/templates/components/frost-action-bar.hbs
@@ -3,7 +3,7 @@
   {{selectedItemsLabel}}
 </div>
 <div class='{{css}}-buttons'>
-  {{#each controls as |control|}}
+  {{#each _controls as |control|}}
     {{component control}}
   {{/each}}
 </div>

--- a/addon/utils/controls.js
+++ b/addon/utils/controls.js
@@ -1,8 +1,4 @@
 /**
- * TODO Controls utilities
- */
-
-/**
  * Takes a hash of types with controls and returns a subset of only the controls that are common across each type.
  * Each key of the object is a type, and each value is an array of associated controls that are applicable to that type.
  *

--- a/addon/utils/controls.js
+++ b/addon/utils/controls.js
@@ -8,7 +8,7 @@
 export function applicableControls (typesWithControlNames) {
   return Object.keys(typesWithControlNames).reduce((controlNames, control) => {
     return _intersect(controlNames, typesWithControlNames[control])
-  }, typesWithControlNames[Object.keys(typesWithControlNames)[0]])
+  }, typesWithControlNames[Object.keys(typesWithControlNames)[0]]) || []
 }
 
 function _intersect (a, b) {

--- a/addon/utils/controls.js
+++ b/addon/utils/controls.js
@@ -1,0 +1,22 @@
+/**
+ * TODO Controls utilities
+ */
+
+/**
+ * Takes a hash of types with controls and returns a subset of only the controls that are common across each type.
+ * Each key of the object is a type, and each value is an array of associated controls that are applicable to that type.
+ *
+ * @param {Object} typesWithControlNames - object/hash of types with associated controls
+ * @returns {Array} list of controls that are common across currently selected items
+ */
+export function applicableControls (typesWithControlNames) {
+  return Object.keys(typesWithControlNames).reduce((controlNames, control) => {
+    return _intersect(controlNames, typesWithControlNames[control])
+  }, typesWithControlNames[Object.keys(typesWithControlNames)[0]])
+}
+
+function _intersect (a, b) {
+  return a.filter((value) => {
+    return b.includes(value)
+  })
+}

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "5.6.0",
     "ember-frost-core": "1.23.10",
-    "ember-frost-list": "5.8.2"
+    "ember-frost-list": "6.1.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
     "configPath": "tests/dummy/config"
   },
   "pr-bumper": {
-    "coverage": 76.34
+    "coverage": 72.44
   }
 }

--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
     "configPath": "tests/dummy/config"
   },
   "pr-bumper": {
-    "coverage": 72.44
+    "coverage": 80.25
   }
 }

--- a/tests/dummy/app/models/list-item.js
+++ b/tests/dummy/app/models/list-item.js
@@ -1,7 +1,8 @@
 import DS from 'ember-data'
 
 var Model = DS.Model.extend({
-  label: DS.attr('string')
+  label: DS.attr('string'),
+  itemType: DS.attr('string')
 })
 
 export default Model

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -15,6 +15,11 @@
         {{#link-to 'client-code'}}Code{{/link-to}}
       </div>
       <div class='frost-modal-demo-selector-title'>
+        Client side control flow with typed list items
+        {{#link-to 'client-typed'}}Demo{{/link-to}}
+        {{#link-to 'client-typed-code'}}Code{{/link-to}}
+      </div>
+      <div class='frost-modal-demo-selector-title'>
         Server side control flow
         {{#link-to 'server'}}Demo{{/link-to}}
         {{#link-to 'server-code'}}Code{{/link-to}}

--- a/tests/dummy/app/pods/client-typed-code/template.hbs
+++ b/tests/dummy/app/pods/client-typed-code/template.hbs
@@ -1,0 +1,12 @@
+<div class='frost-modal-demo-title'>
+  Template
+</div>
+<div class='frost-modal-demo-snippet'>
+  {{code-snippet name='client-typed-template.hbs'}}
+</div>
+<div class='frost-modal-demo-title'>
+  Controller
+</div>
+<div class='frost-modal-demo-snippet'>
+  {{code-snippet name='client-typed-controller.js'}}
+</div>

--- a/tests/dummy/app/pods/client-typed/controller.js
+++ b/tests/dummy/app/pods/client-typed/controller.js
@@ -1,0 +1,185 @@
+/**
+ * TODO
+ */
+
+import Ember from 'ember'
+const {A, Controller, get, inject, isEmpty} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
+import {generateFacetView} from 'ember-frost-bunsen/utils'
+import {sort} from 'ember-frost-sort'
+import _ from 'lodash'
+
+export default Controller.extend({
+
+  // == Dependencies ==========================================================
+
+  notifications: inject.service('notification-messages'),
+
+  // == Keyword Properties
+
+  queryParams: ['filters', 'sortOrder'],
+
+  // == Properties ============================================================
+
+  expandedItems: [],
+  filters: {},
+  filterModel: {
+    type: 'object',
+    properties: {
+      id: {type: 'string'},
+      label: {type: 'string'}
+    }
+  },
+  filterView: generateFacetView([
+    {label: 'Id', model: 'id'},
+    {label: 'Label', model: 'label'}
+  ]),
+  itemsPerPage: 10,
+  page: 0,
+  scrollTop: 0,
+  selectedItems: [],
+  sortOrder: ['id'],
+  sortingProperties: [
+    {label: 'Id', value: 'id'},
+    {label: 'Label', value: 'label'}
+  ],
+  totalItems: 100, // Typically extracted from meta on the request
+  componentKeyNames: {
+    controls: 'controlNames'
+  },
+  componentKeyNamesForTypes: {
+    a: {
+      itemName: 'list-item',
+      itemExpansionName: 'list-item-expansion',
+      controlNames: [
+        'singleSelect'
+      ]
+    },
+    b: {
+      itemName: 'list-item',
+      itemExpansionName: 'list-item-expansion',
+      controlNames: [
+        'multiSelect',
+        'includesF'
+      ]
+    },
+    c: {
+      itemName: 'list-item',
+      itemExpansionName: 'list-item-expansion',
+      controlNames: [
+        'includesF'
+      ]
+    },
+    d: {
+      itemName: 'list-item',
+      itemExpansionName: 'list-item-expansion',
+      controlNames: [
+        'detailsButton'
+      ]
+    },
+    default: {
+      itemName: 'list-item',
+      itemExpansionName: 'list-item-expansion'
+    }
+  },
+
+  // == Computed Properties ===================================================
+
+  @readOnly
+  @computed('selectedItems.@each.id')
+  detailLinkRouteNames (selectedItems) {
+    return selectedItems.map((selectedItem) => {
+      return `${window.location.origin}/#/user/${selectedItem.get('id')}`
+    })
+  },
+
+  @readOnly
+  @computed('filters', 'model.[]', 'page', 'sortOrder.[]')
+  items (filters, model, page, sortOrder) {
+    if (isEmpty(model)) {
+      return []
+    }
+
+    // Client side filtering
+    let filteredItems = model
+    if (!isEmpty(filters)) {
+      filteredItems = model.filter((item) => {
+        return A(Object.keys(filters)).every(key => {
+          return get(item, key).indexOf(get(filters, key)) >= 0
+        })
+      })
+    }
+
+    // Client side sorting
+    const sortedItems = sort(filteredItems, sortOrder)
+
+    // Client side pagination
+    const itemsPerPage = this.get('itemsPerPage')
+    const pageSliceStart = itemsPerPage * page
+    return sortedItems.slice(pageSliceStart, pageSliceStart + itemsPerPage + 1)
+  },
+
+  @readOnly
+  @computed('selectedItems.@each.label')
+  labelIncludesF (selectedItems) {
+    return selectedItems.find((selectedItem) => {
+      return selectedItem.get('label').toLowerCase().includes('f')
+    })
+  },
+
+  // == Functions =============================================================
+
+  fetchPage (page) {
+    this.store.query('list-item', {
+      pageSize: this.get('itemsPerPage'),
+      start: (page * this.get('itemsPerPage'))
+    }).then((response) => {
+      this.set('model', this.store.peekAll('list-item'))
+    })
+  },
+
+  // == Ember Lifecycle Hooks =================================================
+
+  // == Actions ===============================================================
+
+  actions: {
+    // BEGIN-SNIPPET client-typed-controller
+    onExpansionChange (expandedItems) {
+      this.get('expandedItems').setObjects(expandedItems)
+    },
+
+    onFilteringChange (filters) {
+      this.set('filters', _.cloneDeep(filters))
+      this.store.unloadAll('list-item')
+      this.get('selectedItems').clear()
+      this.fetchPage(0)
+    },
+
+    onGenericAction (selectedItems, message) {
+      this.get('notifications').success(message, {
+        autoClear: true,
+        clearDuration: 2000
+      })
+    },
+
+    onPaginationChange (page) {
+      this.setProperties({
+        page,
+        scrollTop: 0
+      })
+      this.fetchPage(page)
+    },
+
+    onSelectionChange (selectedItems) {
+      this.get('selectedItems').setObjects(selectedItems)
+    },
+
+    onSortingChange (sortOrder) {
+      this.get('sortOrder').setObjects(sortOrder)
+      this.store.unloadAll('list-item')
+      this.get('selectedItems').clear()
+      this.fetchPage(0)
+    }
+    // END-SNIPPET
+  }
+})

--- a/tests/dummy/app/pods/client-typed/controller.js
+++ b/tests/dummy/app/pods/client-typed/controller.js
@@ -1,7 +1,3 @@
-/**
- * TODO
- */
-
 import Ember from 'ember'
 const {A, Controller, get, inject, isEmpty} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'

--- a/tests/dummy/app/pods/client-typed/route.js
+++ b/tests/dummy/app/pods/client-typed/route.js
@@ -1,0 +1,9 @@
+import Ember from 'ember'
+const {Route} = Ember
+
+export default Route.extend({
+  setupController (controller, model) {
+    this._super(controller, model)
+    controller.fetchPage(0)
+  }
+})

--- a/tests/dummy/app/pods/client-typed/template.hbs
+++ b/tests/dummy/app/pods/client-typed/template.hbs
@@ -1,0 +1,82 @@
+{{! BEGIN-SNIPPET client-typed-template }}
+{{frost-object-browser
+  hook='clientObjectBrowser'
+  filters=(component 'frost-bunsen-form'
+    autofocus=false
+    bunsenModel=filterModel
+    bunsenView=filterView
+    onChange=(action 'onFilteringChange')
+    value=filters
+  )
+  content=(component 'frost-list'
+    hook='clientList'
+    componentKeyNamesForTypes=componentKeyNamesForTypes
+    itemDefinitions=(hash
+      list-item=(component 'list-item-typed')
+    )
+    itemExpansionDefinitions=(hash
+      list-item-expansion=(component 'list-item-expansion')
+    )
+    itemTypeKey='itemType'
+    item=(component 'list-item')
+    itemExpansion=(component 'list-item-expansion')
+    items=items
+    itemKey='id'
+    expandedItems=expandedItems
+    onExpansionChange=(action 'onExpansionChange')
+    selectedItems=selectedItems
+    onSelectionChange=(action 'onSelectionChange')
+    pagination=(component 'frost-list-pagination'
+      itemsPerPage=itemsPerPage
+      page=page
+      total=totalItems
+      onChange=(action 'onPaginationChange')
+    )
+    sorting=(component 'frost-sort'
+      sortOrder=sortOrder
+      sortingProperties=sortingProperties
+      onChange=(action 'onSortingChange')
+    )
+  )
+  controls=(component 'frost-action-bar'
+    hook='clientActionBar'
+    selectedItems=selectedItems
+    itemTypeKey='itemType'
+    componentKeyNames=componentKeyNames
+    componentKeyNamesForTypes=componentKeyNamesForTypes
+    controls=(hash
+      singleSelect=(component 'frost-button'
+        hook='clientSingleSelectButton'
+        disabled=(single-select selectedItems)
+        priority='secondary'
+        size='medium'
+        text='Single-select'
+        onClick=(action 'onGenericAction' selectedItems 'Single-select enabled action')
+      )
+      multiSelect=(component 'frost-button'
+        hook='clientMultiSelectButton'
+        disabled=(multi-select selectedItems)
+        priority='secondary'
+        size='medium'
+        text='Multi-select'
+        onClick=(action 'onGenericAction' selectedItems 'Multi-select enabled action')
+      )
+      includesF=(component 'frost-button'
+        hook='clientLabelButton'
+        disabled=(not labelIncludesF)
+        priority='secondary'
+        size='medium'
+        text="Label includes 'f'"
+        onClick=(action 'onGenericAction' selectedItems 'Custom enabled action')
+      )
+      detailsButton=(component 'frost-link'
+        hook='clientDetailLink'
+        priority='primary'
+        routeNames=detailLinkRouteNames
+        size='medium'
+        text='Detail'
+      )
+    )
+  )
+}}
+{{! END-SNIPPET}}

--- a/tests/dummy/app/pods/client/controller.js
+++ b/tests/dummy/app/pods/client/controller.js
@@ -1,7 +1,3 @@
-/**
- * TODO
- */
-
 import Ember from 'ember'
 const {A, Controller, get, inject, isEmpty} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'

--- a/tests/dummy/app/pods/components/list-item-typed/_styles.scss
+++ b/tests/dummy/app/pods/components/list-item-typed/_styles.scss
@@ -1,0 +1,5 @@
+.list-item-typed-placeholder {
+  align-self: center;
+  color: $frost-color-grey-5;
+  font-style: italic;
+}

--- a/tests/dummy/app/pods/components/list-item-typed/component.js
+++ b/tests/dummy/app/pods/components/list-item-typed/component.js
@@ -1,0 +1,4 @@
+import FrostListItem from 'ember-frost-list/components/frost-list-item'
+
+export default FrostListItem.extend({
+})

--- a/tests/dummy/app/pods/components/list-item-typed/template.hbs
+++ b/tests/dummy/app/pods/components/list-item-typed/template.hbs
@@ -1,0 +1,3 @@
+<div class='frost-list-item-element-block {{css}}-placeholder'>
+  Placeholder - {{model.label}} - {{model.id}} - type {{model.itemType}}
+</div>

--- a/tests/dummy/app/pods/server/controller.js
+++ b/tests/dummy/app/pods/server/controller.js
@@ -1,7 +1,3 @@
-/**
- * TODO
- */
-
 import Ember from 'ember'
 const {A, Controller, inject, isEmpty} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,6 +12,8 @@ Router.map(function () {
   this.route('helpers')
   this.route('client')
   this.route('client-code')
+  this.route('client-typed')
+  this.route('client-typed-code')
   this.route('server')
   this.route('server-code')
 })

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,5 +1,6 @@
 @import 'node_modules/ember-frost-core/addon/styles/frost-theme';
 @import 'tests/dummy/app/pods/components/list-item/styles';
+@import 'tests/dummy/app/pods/components/list-item-typed/styles';
 @import 'tests/dummy/app/pods/components/list-item-expansion/styles';
 
 .frost-modal-demo {

--- a/tests/factories/list-item.js
+++ b/tests/factories/list-item.js
@@ -10,10 +10,20 @@ FactoryGuy.define('list-item', {
         'baz'
       ]
       return items[num % items.length]
+    },
+    itemType: (num) => {
+      let items = [
+        'a',
+        'b',
+        'c',
+        'd'
+      ]
+      return items[num % items.length]
     }
   },
 
   default: {
-    label: FactoryGuy.generate('label')
+    label: FactoryGuy.generate('label'),
+    itemType: FactoryGuy.generate('itemType')
   }
 })

--- a/tests/integration/components/frost-action-bar-test.js
+++ b/tests/integration/components/frost-action-bar-test.js
@@ -115,4 +115,64 @@ describe(test.label, function () {
       })
     })
   })
+
+  describe('after render with controls as a hash', function () {
+    let formatSelectedItemsLabel, selectedItems
+
+    beforeEach(function () {
+      formatSelectedItemsLabel = sandbox.stub()
+      selectedItems = [
+        {id: 1, itemType: 'a'},
+        {id: 2, itemType: 'b'}
+      ]
+
+      this.setProperties({
+        itemTypeKey: 'itemType',
+        componentKeyNames: {
+          controls: 'controlNames'
+        },
+        componentKeyNamesForTypes: {
+          a: {
+            controlNames: [
+              'action1'
+            ]
+          },
+          b: {
+            controlNames: [
+              'action1',
+              'action2'
+            ]
+          }
+        },
+        formatSelectedItemsLabel: formatSelectedItemsLabel,
+        selectedItems: selectedItems
+      })
+
+      this.render(hbs`
+        {{frost-action-bar
+          hook='bar'
+          hookQualifiers=(hash)
+          itemTypeKey=itemTypeKey
+          componentKeyNames=componentKeyNames
+          componentKeyNamesForTypes=componentKeyNamesForTypes
+          controls=(hash
+            action1=(component 'mock-controls' class='mock-control-1')
+            action2=(component 'mock-controls' class='mock-control-2')
+          )
+          i18n=(hash
+            formatSelectedItemsLabel=formatSelectedItemsLabel
+          )
+          selectedItems=selectedItems
+        }}
+        `)
+    })
+
+    it('should render with the applicable controls', function () {
+      expect(this.$('.frost-action-bar-buttons .mock-control-1')).to.have.length(1)
+    })
+
+    it('should not render the inapplicable controls', function () {
+      expect(this.$('.frost-action-bar-buttons .mock-control-2')).to.have.length(0)
+    })
+  })
 })

--- a/tests/unit/utils/controls-test.js
+++ b/tests/unit/utils/controls-test.js
@@ -1,0 +1,52 @@
+import {expect} from 'chai'
+import {applicableControls} from 'ember-frost-object-browser/utils/controls'
+import {beforeEach, describe, it} from 'mocha'
+
+describe('Unit | Utility | controls', function () {
+  describe('applicableControls()', function () {
+    describe('when there is one common control among all types', function () {
+      let typesWithControlNames
+
+      beforeEach(function () {
+        typesWithControlNames = {
+          a: ['action1', 'action2'],
+          b: ['action2', 'action3']
+        }
+      })
+
+      it('should return a list containing one control name', function () {
+        expect(applicableControls(typesWithControlNames)).to.be.eql(['action2'])
+      })
+    })
+
+    describe('when there are two common controls among types', function () {
+      let typesWithControlNames
+
+      beforeEach(function () {
+        typesWithControlNames = {
+          a: ['action1', 'action2', 'action3'],
+          b: ['action2', 'action3', 'action4']
+        }
+      })
+
+      it('should return a list containing two control names', function () {
+        expect(applicableControls(typesWithControlNames)).to.be.eql(['action2', 'action3'])
+      })
+    })
+
+    describe('when there are no common controls among types', function () {
+      let typesWithControlNames
+
+      beforeEach(function () {
+        typesWithControlNames = {
+          a: ['action1', 'action2'],
+          b: ['action3', 'action4']
+        }
+      })
+
+      it('should return an empty list', function () {
+        expect(applicableControls(typesWithControlNames)).to.be.eql([])
+      })
+    })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

You can now specify `itemTypeKey`, `componentKeyNames`, and `componentKeyNamesForTypes` in addition to changing `controls` from an array of components to a hash of components, in order to produce an object browser that can take advantage of this new functionality. It can conditionally show certain controls based on the type of the list item. If multiple list items are selected, it will only show the controls that are applicable to all of the selected items. 

# CHANGELOG
* **Added** ability for object browser to render list list items with different types
* **Added** ability for action bar to show certain controls based on list item type