### PR TITLE
Remove unused ember-simple-uuid dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,6 @@
     "jquery-mockjax": "2.2.1",
     "lodash": "^4.10.0",
     "mocha": "^2.2.4",
-    "node-uuid": "1.4.7",
     "pretender": "^0.10.1",
     "perfect-scrollbar": ">=0.6.7 <2.0.0",
     "clockpicker-seconds": "~0.1.6"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "ember-prop-types": "^3.11.0",
     "ember-resolver": "^2.0.3",
     "ember-run-raf": "1.1.2",
-    "ember-simple-uuid": "~0.1.4",
     "ember-sinon": "~0.6.0",
     "ember-sortable": "~1.9.3",
     "ember-source": "~2.11.0",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Remove unused `ember-simple-uuid` dependency