### PR TITLE
Add support for a loading animation to be displayed in the action bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ ember install ember-frost-object-browser
 
 ### Action Bar
 
-| Attribute        | Type          | Value | Description                                        |
-| ---------------- | ------------- | ----- | -------------------------------------------------- |
-| controls         | `array`       |       | Controls that will be available in the action bar  |
-| isLoading        | `boolean`     |       | Whether or not the action bar is a loading state   |
-| loadingText      | `string`      |       | Text that appears beside the loading animation     |
-| selectedItems    | `array`       |       | List of items that are currently selected          |
+| Attribute        | Type          | Value | Description                                         |
+| ---------------- | ------------- | ----- | --------------------------------------------------- |
+| controls         | `array`       |       | Controls that will be available in the action bar   |
+| isLoading        | `boolean`     | false | **default** - Action bar is not in a loading state  |
+|                  |               | true  | Action bar is in a loading state                    |
+| loadingText      | `string`      |       | Text that appears beside the loading animation      |
+| selectedItems    | `array`       |       | List of items that are currently selected           |
 
 ## Examples
 
@@ -133,7 +134,7 @@ onSortingChange (sortOrder) {…}
   }}
 ```
 
-A scenario where the loading state in the action bar might be useful is if there is some amount of processing that needs to be done in order to determine the state of the controls within the action bar. For example, determining whether a button should be enabled/disabled or shown/hidden.
+A scenario where the loading state in the action bar might be useful is if there is some amount of processing that needs to be done in order to determine the state of the controls within the action bar. For example, determining whether a button should be enabled/disabled or shown/hidden. Note that the loading animation is the ring type from [ember-frost-core](https://github.com/ciena-frost/ember-frost-core).
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 # ember-frost-object-browser
 
  * [Installation](#installation)
+ * [API](#api)
  * [Examples](#examples)
+ * [Demo](#demo)
  * [Development](#development)
 
 ## Installation
@@ -20,8 +22,23 @@
 ember install ember-frost-object-browser
 ```
 
+## API
+
+### Action Bar
+
+| Attribute        | Type          | Value | Description                                        |
+| ---------------- | ------------- | ----- | -------------------------------------------------- |
+| controls         | `array`       |       | Controls that will be available in the action bar  |
+| isLoading        | `boolean`     |       | Whether or not the action bar is a loading state   |
+| loadingText      | `string`      |       | Text that appears beside the loading animation     |
+| selectedItems    | `array`       |       | List of items that are currently selected          |
+
 ## Examples
-### Template:
+
+### Object Browser
+
+#### Template
+
 ```handlebars
 {{frost-object-browser
   filters=(component 'frost-bunsen-form'
@@ -84,7 +101,7 @@ ember install ember-frost-object-browser
 }}
 ```
 
-### Controller:
+#### Controller:
 
 Your controller can implement the following callbacks:
 
@@ -95,6 +112,30 @@ onPaginationChange (page) {…}
 onSelectionChange (selectedItems) {…}
 onSortingChange (sortOrder) {…}
 ```
+
+### Action Bar
+
+#### Template
+
+```handlebars
+  {{frost-action-bar
+    controls=array(
+      (component 'frost-link'
+        priority='primary'
+        routeNames=detailLinkRouteNames
+        size='medium'
+        text='Detail'
+      )
+    )
+    isLoading=isLoading
+    loadingText='Loading actions'
+    selectedItems=selectedItems
+  }}
+```
+
+A scenario where the loading state in the action bar might be useful is if there is some amount of processing that needs to be done in order to determine the state of the controls within the action bar. For example, determining whether a button should be enabled/disabled or shown/hidden.
+
+## Demo
 
 Check out http://ciena-frost.github.io/ember-frost-object-browser/ for the demo app bundled with this addon to see
 an example of using this addon.

--- a/addon/components/frost-action-bar.js
+++ b/addon/components/frost-action-bar.js
@@ -40,12 +40,12 @@ export default Component.extend({
       PropTypes.EmberObject,
       PropTypes.object
     ]),
+    isLoading: PropTypes.bool,
 
     // callbacks
-    getSelectedItemsLabel: PropTypes.func,
+    getSelectedItemsLabel: PropTypes.func
 
     // state
-    isLoading: PropTypes.bool
   },
 
   getDefaultProps () {
@@ -57,11 +57,11 @@ export default Component.extend({
           return `${count} ${items} selected`
         }
       },
+      isLoading: false
 
       // callbacks
 
       // state
-      isLoading: false
     }
   },
 

--- a/addon/components/frost-action-bar.js
+++ b/addon/components/frost-action-bar.js
@@ -42,9 +42,10 @@ export default Component.extend({
     ]),
 
     // callbacks
-    getSelectedItemsLabel: PropTypes.func
+    getSelectedItemsLabel: PropTypes.func,
 
     // state
+    isLoading: PropTypes.bool
   },
 
   getDefaultProps () {
@@ -55,11 +56,12 @@ export default Component.extend({
           const items = (count > 1) ? 'Items' : 'Item'
           return `${count} ${items} selected`
         }
-      }
+      },
 
       // callbacks
 
       // state
+      isLoading: false
     }
   },
 

--- a/addon/styles/_frost-action-bar.scss
+++ b/addon/styles/_frost-action-bar.scss
@@ -1,5 +1,7 @@
 $frost-action-bar-box-shadow-color: rgba(0, 0, 0, 0.2);
 $frost-action-bar-background-color: rgba($frost-color-white, 0.85);
+$frost-action-bar-loading-dimension: 35px;
+$frost-action-bar-loading-text-margin: calc(#{$frost-action-bar-loading-dimension} - #{$frost-font-s});
 
 .frost-action-bar {
   display: flex;
@@ -18,6 +20,23 @@ $frost-action-bar-background-color: rgba($frost-color-white, 0.85);
     align-self: center;
     color: $frost-color-grey-3;
     font-size: $frost-font-s;
+  }
+
+  &-loading {
+    display: flex;
+    flex-direction: row;
+
+    .frost-loading {
+      width: $frost-action-bar-loading-dimension;
+      height: $frost-action-bar-loading-dimension;
+      margin: 0 15px;
+    }
+
+    .loading-text {
+      margin-top: calc(#{$frost-action-bar-loading-text-margin} / 2);
+      color: $frost-color-blue-1;
+      font-size: $frost-font-s;
+    }
   }
 
   &-buttons {

--- a/addon/templates/components/frost-action-bar.hbs
+++ b/addon/templates/components/frost-action-bar.hbs
@@ -2,6 +2,15 @@
 <div class='{{css}}-selections'>
   {{selectedItemsLabel}}
 </div>
+<div class='{{css}}-loading'>
+  {{#if isLoading}}
+    {{frost-loading
+      hook=(concat hookPrefix '-loading')
+      type='ring'
+    }}
+    <div class='loading-text'>{{loadingText}}</div>
+  {{/if}}
+</div>
 <div class='{{css}}-buttons'>
   {{#each _controls as |control|}}
     {{component control}}

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -15,7 +15,7 @@
         {{#link-to 'client-code'}}Code{{/link-to}}
       </div>
       <div class='frost-modal-demo-selector-title'>
-        Client side control flow with typed list items
+        Client side control flow with typed list items and action bar loading animation
         {{#link-to 'client-typed'}}Demo{{/link-to}}
         {{#link-to 'client-typed-code'}}Code{{/link-to}}
       </div>

--- a/tests/dummy/app/pods/client-typed/controller.js
+++ b/tests/dummy/app/pods/client-typed/controller.js
@@ -1,5 +1,5 @@
 import Ember from 'ember'
-const {A, Controller, get, inject, isEmpty} = Ember
+const {A, Controller, get, inject, isEmpty, isPresent, run} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {generateFacetView} from 'ember-frost-bunsen/utils'
 import {sort} from 'ember-frost-sort'
@@ -30,7 +30,9 @@ export default Controller.extend({
     {label: 'Id', model: 'id'},
     {label: 'Label', model: 'label'}
   ]),
+  isLoading: false,
   itemsPerPage: 10,
+  loadingText: 'Loading actions',
   page: 0,
   scrollTop: 0,
   selectedItems: [],
@@ -134,6 +136,10 @@ export default Controller.extend({
     })
   },
 
+  doneLoading () {
+    this.set('isLoading', false)
+  },
+
   // == Ember Lifecycle Hooks =================================================
 
   // == Actions ===============================================================
@@ -168,6 +174,14 @@ export default Controller.extend({
 
     onSelectionChange (selectedItems) {
       this.get('selectedItems').setObjects(selectedItems)
+      if (isPresent(selectedItems)) {
+        this.set('isLoading', true)
+        this.get('notifications').success('Set isLoading flag to true', {
+          autoClear: true,
+          clearDuration: 2000
+        })
+        run.debounce(this, this.doneLoading, 2000)
+      }
     },
 
     onSortingChange (sortOrder) {

--- a/tests/dummy/app/pods/client-typed/template.hbs
+++ b/tests/dummy/app/pods/client-typed/template.hbs
@@ -41,7 +41,9 @@
   controls=(component 'frost-action-bar'
     hook='clientActionBar'
     selectedItems=selectedItems
+    isLoading=isLoading
     itemTypeKey='itemType'
+    loadingText=loadingText
     componentKeyNames=componentKeyNames
     componentKeyNamesForTypes=componentKeyNamesForTypes
     controls=(hash

--- a/tests/dummy/app/pods/client/template.hbs
+++ b/tests/dummy/app/pods/client/template.hbs
@@ -31,6 +31,8 @@
   )
   controls=(component 'frost-action-bar'
     hook='clientActionBar'
+    isLoading=true
+    loadingText='Loading actions'
     selectedItems=selectedItems
     controls=(array
       (component 'frost-button'

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -33,6 +33,7 @@
 
 .frost-modal-demo-selectors {
   min-width: 100px;
+  max-width: 300px;
   height: calc(100vh - 61px);
   margin: 10px 0 10px 10px;
   padding-right: 20px;

--- a/tests/integration/components/frost-action-bar-test.js
+++ b/tests/integration/components/frost-action-bar-test.js
@@ -175,4 +175,32 @@ describe(test.label, function () {
       expect(this.$('.frost-action-bar-buttons .mock-control-2')).to.have.length(0)
     })
   })
+
+  describe('after render with loading options provided', function () {
+    beforeEach(function () {
+      this.setProperties({
+        isLoading: true,
+        loadingText: 'Loading actions'
+      })
+
+      this.render(hbs`
+        {{frost-action-bar
+          controls=(array (component 'mock-controls' class='mock-controls'))
+          hook='frost-action-bar'
+          hookQualifiers=(hash)
+          isLoading=isLoading
+          loadingText=loadingText
+          selectedItems=selectedItems
+        }}
+      `)
+    })
+
+    it('should render with a loading animation', function () {
+      expect(this.$('.frost-action-bar-loading')).to.have.length(1)
+    })
+
+    it('should render with the provided loading text', function () {
+      expect(this.$('.frost-action-bar-loading .loading-text').text()).to.equal('Loading actions')
+    })
+  })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

This change adds support for a loading animation in the action bar, which is part of the UX specification at Ciena. See screen shot below for an example of what it will look like

![image](https://user-images.githubusercontent.com/1317293/32914218-ce5c516a-cae2-11e7-9c04-a16c6d39f1c9.png)

Closes #144 

# CHANGELOG

* Added support for displaying a loading animation in the action bar
