### PR TITLE
Fixes "Could not find module `symbol-observable/polyfill.js`"

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "loader.js": "^4.2.3",
     "pr-bumper": "^1.11.0",
     "sinon-chai": "^2.9.0",
-    "smoke-and-mirrors": "0.6.2"
+    "smoke-and-mirrors": "0.6.2",
+    "symbol-observable": "1.0.4"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Added** `symbol-observable` at version `1.0.4` to avoid changes being received due to the float: https://github.com/mike-north/ember-symbol-observable/blob/6c6bd65a161b20a9f0f308395ad0553086ca6968/package.json#L50