### PR TITLE
Remove unneeded ember-symbol-observable and symbol-observable

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,14 +77,12 @@
     "ember-sortable": "~1.9.3",
     "ember-source": "~2.12.0",
     "ember-spread": "^3.0.1",
-    "ember-symbol-observable": "~0.1.2",
     "ember-test-utils": "^4.0.0",
     "ember-truth-helpers": "^1.3.0",
     "loader.js": "^4.2.3",
     "pr-bumper": "^1.11.0",
     "sinon-chai": "^2.9.0",
-    "smoke-and-mirrors": "0.6.2",
-    "symbol-observable": "1.0.4"
+    "smoke-and-mirrors": "0.6.2"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Removed** unneeded `ember-symbol-observable` and `symbol-observable` that were brought in via `ember-frost-bunsen` via the blueprints of `ember-redux-shim`