### PR TITLE
Fix action bar is rendered outside viewport issue in Firefox

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -22,6 +22,7 @@ $frost-object-browser-actions-box-shadow: 0 8px 8px -8px #696868, 0 -8px 8px -8p
     display: flex;
     flex-direction: column;
     height: 100%;
+    min-height: 0;
   }
 
   .frost-list-content-container {


### PR DESCRIPTION
Fixed #131

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** bug that action bar is rendered outside viewport when selecting an item in Firefox.