### PR TITLE
ISSUE #157: clear button drop shadow no longer gets cutoff

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -94,6 +94,12 @@ $frost-object-browser-actions-box-shadow: 0 8px 8px -8px #696868, 0 -8px 8px -8p
       background-color: $frost-color-lgrey-1;
     }
 
+    .frost-bunsen-heading {
+      .frost-button {
+        margin-right: 2px;
+      }
+    }
+
     .frost-bunsen-input-text {
       &.frost-field {
         div {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

before:
![image](https://user-images.githubusercontent.com/29387/33582051-2c6017dc-d908-11e7-9566-5a9870642abb.png)

after:
![image](https://user-images.githubusercontent.com/29387/33582059-3710ffca-d908-11e7-95f6-63a31ca61b2f.png)

# CHANGELOG
* Fixes #157, drop shadow on the `clear` buttons in filter facets was being cutoff, gave it 2px of margin to show