### PR TITLE
Fix controls not put in more actions properly

### DIFF
--- a/addon/templates/components/frost-action-bar.hbs
+++ b/addon/templates/components/frost-action-bar.hbs
@@ -18,7 +18,7 @@
       data-test={{hook 'moreActions'}}>
       {{frost-button
         hook='moreActions-button'
-        priority='secondary'
+        priority='tertiary'
         size='medium'
         text=moreActionsText
       }}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,6 @@
     "configPath": "tests/dummy/config"
   },
   "pr-bumper": {
-    "coverage": 95
+    "coverage": 94
   }
 }

--- a/tests/integration/components/frost-action-bar-test.js
+++ b/tests/integration/components/frost-action-bar-test.js
@@ -336,9 +336,9 @@ describe(test.label, function () {
               (component 'frost-button' class="test-button" text='button 3')
               (component 'frost-button' class="test-button" text='button 4')
               (component 'frost-button' class="test-button" text='button 5')
+              (component 'frost-button' class="test-button" text='button 6')
             )
             moreActions=(array
-              (component 'frost-button' class="test-button" text='button 6')
               (component 'frost-button' class="test-button" text='button 7')
               (component 'frost-button' class="test-button" text='button 8')
               (component 'frost-button' class="test-button" text='button 9')
@@ -352,11 +352,11 @@ describe(test.label, function () {
 
       it('should put moreActions into moreActions button', function () {
         const $moreButton = $hook('moreActions')
-        expect($moreButton.find('li').length).to.equal(4)
+        expect($moreButton.find('li').length).to.equal(5)
       })
 
-      it('should not put any controls into the moreActions', function () {
-        expect($hook('frost-action-bar-buttons').children('.test-button').length).to.equal(5)
+      it('should put excess controls into the moreActions', function () {
+        expect($hook('frost-action-bar-buttons').children('.test-button').length).to.equal(4)
       })
     })
 


### PR DESCRIPTION
# Overview

## Summary
When more actions are passed in the excess controls now properly get put into the more button along with the passed in more actions. Also "More" button is now a tertiary button as per UX specs

## Screenshots or recordings

### Before
<img width="887" alt="screen shot 2018-08-23 at 11 43 27 am" src="https://user-images.githubusercontent.com/12944605/44585747-5a252580-a77b-11e8-9230-78373d2a801f.png">

### After
<img width="886" alt="screen shot 2018-08-23 at 11 44 29 am" src="https://user-images.githubusercontent.com/12944605/44585759-601b0680-a77b-11e8-8b96-c67b760ddeb6.png">

# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [x] #patch#
- [ ] #minor#
- [ ] #major#

# CHANGELOG

* Fix excess controls not being put under more button when there are passed in more actions